### PR TITLE
Fix circle-ci build output and push target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run:
           name: Build Docker Images
           command: |
-            echo "$DOCKERHUB_PASS" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+            echo "$REPO_PASSWORD" | docker login --username "$REPO_USERNAME" --password-stdin
             make
             make list
             make push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,5 +33,6 @@ jobs:
           command: |
             echo "$DOCKERHUB_PASS" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
             make
+            make list
             make push
             make push-readme

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ $(RELEASES):
 		--tag $(REPO_NAMESPACE)/$(IMAGE_NAME):$(VCS_REF)$(TAG_SUFFIX) \
 		--tag $(REPO_NAMESPACE)/$(IMAGE_NAME):$(VERSION) \
 		--tag $(REPO_NAMESPACE)/$(IMAGE_NAME):$(VERSION)$(TAG_SUFFIX) \
+		--progress=$(BUILD_PROGRESS) \
 		--file Dockerfile .
 
 # List built images
@@ -93,7 +94,7 @@ test:
 # Push images to repo
 .PHONY: push
 .SILENT: push
-push: build
+push:
 	echo "$$REPO_PASSWORD" | docker login -u "$(REPO_USERNAME)" --password-stdin; \
 		docker push  $(REPO_NAMESPACE)/$(IMAGE_NAME):latest; \
 		docker push  $(REPO_NAMESPACE)/$(IMAGE_NAME):$(VCS_REF)$(TAG_SUFFIX); \


### PR DESCRIPTION
This ensures that the docker build output can be set in pipelines using:
```
BUILD_PROGRESS=plain
```

This will ensure the build output is readable as Docker buildkit now uses ncurses by default