### PR TITLE
Add GNU Grep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN set -xe; \
         gawk \
         gettext \
         git \
+        grep \
         htop \
         jq \
         krb5-libs \


### PR DESCRIPTION
Added GNU Grep (the default is busybox) which resolves issues with misc
scripts and pre-commit hooks on projects